### PR TITLE
Better handling of network errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,3 @@ commands = {posargs:django-admin --help}
 ignore = E128
 exclude = yarrharr/wsgi.py,yarrharr/migrations/*.py
 max-line-length = 120
-max-complexity = 10


### PR DESCRIPTION
Various network error conditions are expected, if not inevitable, and don't really merit a full traceback (which doesn't tell us much anyway). Add a new fetch result type which just saves the exception error message.