### PR TITLE
Bump React to 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "normalize.css": "^7.0.0",
     "prop-types": "^15.5.7",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-redux": "~4.4.8",
     "redux": "~3.7.2",
     "redux-logger": "~3.0.6",


### PR DESCRIPTION
Explicitly depend on React 16.2.0 now that React.Fragment is in use.