### PR TITLE
Fix feed double-sanitization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ setup(
         'Twisted[tls] ~= 17.9.0',
         'treq ~= 17.8.0',
         'pytz',
-        # Note: feedparser was refactored into a package after 5.2.1, which
-        # moved feedparser.SANITIZE_HTML to feedparser.api.SANITIZE_HTML.
+        # We are (hopefully temporarily) using a fork of feedparser as the
+        # maintainer is MIA.
         # 'feedparser > 5.2.1',
-        'forkparser ~= 6.0.0',
+        'forkparser ~= 6.1.0',
         'simplejson >= 2.1.0',  # for JSONEncoderForHTML
         'html5lib == 0.999999999',
     ],

--- a/yarrharr/examples/html-script.rss
+++ b/yarrharr/examples/html-script.rss
@@ -1,0 +1,26 @@
+<rss version="2.0">
+<channel>
+  <title>
+    Contains Unsafe HTML
+  </title>
+  <link>http://example.com/rss</link>
+  <description>
+    The article in this file contains a HTML script tag which must eventually
+    be sanitized away.
+  </description>
+  <item>
+    <guid>
+      http://example.com/news/1
+    </guid>
+    <title>
+      I have &lt;script&gt;
+    </title>
+    <link>
+      http://example.com/news/1
+    </link>
+    <description><![CDATA[
+      <script>alert("injected!")</script>
+    ]]></description>
+  </item>
+</channel>
+</rss>

--- a/yarrharr/fetch.py
+++ b/yarrharr/fetch.py
@@ -62,7 +62,7 @@ log = Logger()
 
 # Disable feedparser's HTML sanitization, as it drops important information
 # (like YouTube embeds). We do our own sanitization with html5lib.
-feedparser.api.SANITIZE_HTML = False
+feedparser.mixin.SANITIZE_HTML = False
 
 
 @attr.s(slots=True, frozen=True)

--- a/yarrharr/fetch.py
+++ b/yarrharr/fetch.py
@@ -60,11 +60,6 @@ except:
 log = Logger()
 
 
-# Disable feedparser's HTML sanitization, as it drops important information
-# (like YouTube embeds). We do our own sanitization with html5lib.
-feedparser.mixin.SANITIZE_HTML = False
-
-
 @attr.s(slots=True, frozen=True)
 class BadStatus(object):
     """
@@ -425,7 +420,11 @@ def poll_feed(feed, client=treq):
     # so we wrap it in a BytesIO() to force it to parse the response.
     # Otherwise the HTTP response body could be just a URL and trigger
     # blocking I/O!
-    parsed = feedparser.parse(BytesIO(raw_bytes), response_headers=h)
+    parsed = feedparser.parse(
+        BytesIO(raw_bytes),
+        response_headers=h,
+        sanitize_html=False,
+    )
 
     articles = []
     for entry in parsed['entries']:

--- a/yarrharr/tests/test_fetch.py
+++ b/yarrharr/tests/test_fetch.py
@@ -226,6 +226,19 @@ class ErrorTreq(object):
 
 
 class FetchTests(SynchronousTestCase):
+    def test_raw_content_not_sanitized(self):
+        """
+        feedparser's HTML sanitization is disabled so that we can implement
+        custom sanitization.
+        """
+        feed = FetchFeed()
+        xml = resource_string('yarrharr', 'examples/html-script.rss')
+        client = StubTreq(StaticResource(xml))
+
+        outcome = self.successResultOf(poll_feed(feed, client))
+
+        self.assertIn(u'<script>', outcome.articles[0].raw_content)
+
     def test_title_html(self):
         """
         HTML in feed and article titles is sanitized.


### PR DESCRIPTION
Pull in the API changes from https://github.com/kurtmckee/feedparser/pull/120 so that feeds are not double-sanitized.