### PR TITLE
Redirect to /inventory/ after removing a feed

### DIFF
--- a/assets/actions.js
+++ b/assets/actions.js
@@ -577,6 +577,7 @@ export function removeFeed(feedId) {
         return post('/api/inventory/', body).then(json => {
             // TODO: Handle expected error conditions.
             const { feedsById, feedOrder, labelsById, labelOrder } = json;
+            dispatch(setPath('/inventory'));
             dispatch(receiveLabels(labelsById, labelOrder));
             dispatch(receiveFeeds(feedsById, feedOrder));
         }).catch(e => {


### PR DESCRIPTION
Right now a blank page is displayed.