### PR TITLE
Clean up some log messages

### DIFF
--- a/yarrharr/fetch.py
+++ b/yarrharr/fetch.py
@@ -254,7 +254,7 @@ class BozoError(object):
         feed.etag = b''
         feed.last_modified = b''
         feed.digest = b''
-        feed.error = u'Fetch failed: processing HTTP {} {} response produced error: {!a}'.format(
+        feed.error = u'Fetch failed: processing HTTP {} {} response produced error: {}'.format(
             self.code, self.content_type, self.error)
         schedule(feed)
         feed.save()

--- a/yarrharr/fetch.py
+++ b/yarrharr/fetch.py
@@ -191,7 +191,7 @@ class MaybeUpdated(object):
                 content_rev=REVISION,
             )
             created.save()
-            log.debug("  created {created} (No match for GUID {guid!r} or URL {url!r})",
+            log.debug("  created {created!a} (No match for GUID {guid!r} or URL {url!r})",
                       created=created, guid=upsert.guid, url=upsert.url)
             return
 
@@ -213,7 +213,7 @@ class MaybeUpdated(object):
             match.raw_content = upsert.raw_content
             match.content = sanitize_html(upsert.raw_content)
             match.save()
-            log.debug("  updated {updated} based on {match_type}",
+            log.debug("  updated {updated!a} based on {match_type}",
                       updated=match, match_type=match_type)
 
 
@@ -247,7 +247,7 @@ class BozoError(object):
         feed.etag = b''
         feed.last_modified = b''
         feed.digest = b''
-        feed.error = u'Fetch failed: processing HTTP {} {} response produced error: {}'.format(
+        feed.error = u'Fetch failed: processing HTTP {} {} response produced error: {!a}'.format(
             self.code, self.content_type, self.error)
         schedule(feed)
         feed.save()
@@ -334,7 +334,7 @@ def extract_etag(headers):
     except IndexError:
         etag = b''
     if len(etag) > 1024:
-        log.debug('Ignoring oversizzed ETag header ({count} bytes)', count=len(etag))
+        log.debug('Ignoring oversized ETag header ({count} bytes)', count=len(etag))
         etag = b''
     return etag
 
@@ -377,7 +377,7 @@ def poll_feed(feed, client=treq):
         raw_bytes = yield response.content()
     except (
         # DNS resolution failed. I'm not sure how exactly this is distinct from
-        # UnknownHostError which is a subclass of ConnectError, but this is the
+        # UnknownHostError which is a subclass of ConnectError, but this is
         # what I have observed. Perhaps this is what HostnameEndpoint produces.
         error.DNSLookupError,
         # Failed to establish a TCP connection (includes refused, etc.).


### PR DESCRIPTION
Don't allow newlines or arbitrary server-provided Unicode into the log messages.