### PR TITLE
Bump content revision

### DIFF
--- a/yarrharr/sanitize.py
+++ b/yarrharr/sanitize.py
@@ -34,7 +34,7 @@ from html5lib.constants import namespaces
 from html5lib.filters.base import Filter as BaseFilter
 from hyperlink import URL
 
-REVISION = 2
+REVISION = 3
 
 STYLE_TAG = '{http://www.w3.org/1999/xhtml}style'
 SCRIPT_TAG = '{http://www.w3.org/1999/xhtml}script'

--- a/yarrharr/tests/test_sanitize.py
+++ b/yarrharr/tests/test_sanitize.py
@@ -93,6 +93,10 @@ class SanitizeHtmlTests(unittest.TestCase):
         when setting text color, or contain ``float`` declarations.
         """
         self.assertEqual('<p>.', sanitize_html('<p style="float: left">.'))
+        self.assertEqual(
+            u'<span>.</span>',
+            sanitize_html(u'<span style="display:none">.</span>'),
+        )
 
     def test_script_dropped(self):
         """
@@ -110,7 +114,7 @@ class SanitizeHtmlTests(unittest.TestCase):
         for s in scripts:
             self.assertEqual(u'<p>Hello, world!', sanitize_html(s))
 
-    def test_style_dropped(self):
+    def test_style_tag_dropped(self):
         """
         The content of a ``<style>`` tag is dropped, silently. Sometimes feeds
         contain styles by accident.


### PR DESCRIPTION
Some articles seem to still be on an old content revision, causing lots
of CSP reports due to inline styles. Bumping the revision number forces
them to be re-sanitized on upgrade.