### PR TITLE
Remove swipe support

### DIFF
--- a/assets/base.less
+++ b/assets/base.less
@@ -26,6 +26,7 @@ html {
     overflow-y: scroll;
     color: var(--text-color);
     background: var(--background-color);
+    touch-action: manipulation;
 
     a {
         color: var(--text-color);

--- a/assets/widgets/ListArticle.js
+++ b/assets/widgets/ListArticle.js
@@ -33,65 +33,8 @@ const MAX_SLIDE = 70;
  *     link: article on source site                         |     |
  *                                        button: toggle read     |
  *                                           link: view in Yarrharr
- *
- * The row can also be dragged right to toggle read or left to toggle
- * fave.
  */
 export default class ListArticle extends React.PureComponent {
-    constructor(props) {
-        super(props);
-        this.state = {
-            dx: 0,
-        };
-        this.dragPointer = null;
-        this.x0 = null;
-        this.suppressNextClick = false;
-        this.onDown = event => {
-            console.log('onDown', event.pointerId, event.pageX);
-            if (this.dragPointer == null) {
-                event.target.setPointerCapture(event.pointerId);
-                this.dragPointer = event.pointerId;
-                this.x0 = event.pageX;
-            }
-        };
-        this.onDrag = event => {
-            if (this.dragPointer !== event.pointerId) return;
-            // TODO cap dx in each direction, animate action icon and text appearing
-            const dx = event.pageX - this.x0;
-            console.log('onMove', event.pointerId, event.pageX, dx);
-            this.setState({dx});
-        };
-        this.onCancel = event => {
-            if (this.dragPointer !== event.pointerId) return;
-            console.log('onCancel', event);
-            this.dragPointer = null;
-            this.setState({dx: 0});
-        };
-        this.onUp = event => {
-            if (this.dragPointer !== event.pointerId) return;
-            const dx = event.pageX - this.x0;
-            console.log('onUp', event.pointerId, event.pageX, dx);
-            if (dx < -MIN_SLIDE) {
-                console.log('markFave');
-                this.props.onMarkArticlesFave([this.props.id], !this.props.fave);
-                this.suppressNextClick = true;
-            } else if (dx > MIN_SLIDE) {
-                console.log('markRead');
-                this.props.onMarkArticlesRead([this.props.id], !this.props.read);
-                this.suppressNextClick = true;
-            }
-            this.dragPointer = null;
-            this.setState({dx: 0});
-        }
-        this.onClickCapture = event => {
-            // Prevent buttons and links in sub-components from handling the event when dragging.
-            if (this.suppressNextClick) {
-                event.preventDefault();
-                event.stopPropagation();
-                this.suppressNextClick = false;
-            }
-        };
-    }
     render() {
         const props = this.props;
         if (props.loading) {
@@ -100,23 +43,9 @@ export default class ListArticle extends React.PureComponent {
                 </div>
             </div>
         }
-        var {dx} = this.state;
-        if (dx < -MAX_SLIDE) {
-            dx = -MAX_SLIDE;
-        } else if (dx > MAX_SLIDE) {
-            dx = MAX_SLIDE;
-        }
         return <div className="list-article">
             <div className="list-article-inner">
-                <div className="list-article-slider"
-                        onPointerDown={this.onDown}
-                        onPointerMove={this.onDrag}
-                        onPointerUp={this.onUp}
-                        onPointerCancel={this.onCancel}
-                        onClickCapture={this.onClickCapture}
-                        onDragStart={cancel}
-                        style={{transform: `translateX(${dx}px)`}}
-                    >
+                <div className="list-article-slider">
                     <a className="outbound" href={props.url} target="_blank" title="View on source site" onDragStart={cancel}>
                         <span className="meta">{props.feed.text || props.feed.title} — <RelativeTime then={props.date} /></span>
                         <span className="title">{props.title || "Untitled"} {props.fave ? HEART_ICON : null}</span>

--- a/assets/widgets/ListArticle.js
+++ b/assets/widgets/ListArticle.js
@@ -47,7 +47,7 @@ export default class ListArticle extends React.PureComponent {
         this.x0 = null;
         this.suppressNextClick = false;
         this.onDown = event => {
-            // console.log('onDown', event.pointerId, event.pageX);
+            console.log('onDown', event.pointerId, event.pageX);
             if (this.dragPointer == null) {
                 event.target.setPointerCapture(event.pointerId);
                 this.dragPointer = event.pointerId;
@@ -58,17 +58,25 @@ export default class ListArticle extends React.PureComponent {
             if (this.dragPointer !== event.pointerId) return;
             // TODO cap dx in each direction, animate action icon and text appearing
             const dx = event.pageX - this.x0;
-            // console.log('onMove', event.pointerId, event.pageX, dx);
+            console.log('onMove', event.pointerId, event.pageX, dx);
             this.setState({dx});
+        };
+        this.onCancel = event => {
+            if (this.dragPointer !== event.pointerId) return;
+            console.log('onCancel', event);
+            this.dragPointer = null;
+            this.setState({dx: 0});
         };
         this.onUp = event => {
             if (this.dragPointer !== event.pointerId) return;
             const dx = event.pageX - this.x0;
-            // console.log('onUp', event.pointerId, event.pageX, dx);
-            if (dx < -MIN_SLIDE && dx <= -MAX_SLIDE) {
+            console.log('onUp', event.pointerId, event.pageX, dx);
+            if (dx < -MIN_SLIDE) {
+                console.log('markFave');
                 this.props.onMarkArticlesFave([this.props.id], !this.props.fave);
                 this.suppressNextClick = true;
-            } else if (dx > MAX_SLIDE && dx >= MAX_SLIDE) {
+            } else if (dx > MIN_SLIDE) {
+                console.log('markRead');
                 this.props.onMarkArticlesRead([this.props.id], !this.props.read);
                 this.suppressNextClick = true;
             }
@@ -104,7 +112,7 @@ export default class ListArticle extends React.PureComponent {
                         onPointerDown={this.onDown}
                         onPointerMove={this.onDrag}
                         onPointerUp={this.onUp}
-                        onPointerCancel={this.onUp}
+                        onPointerCancel={this.onCancel}
                         onClickCapture={this.onClickCapture}
                         onDragStart={cancel}
                         style={{transform: `translateX(${dx}px)`}}

--- a/assets/widgets/ListArticle.less
+++ b/assets/widgets/ListArticle.less
@@ -12,9 +12,6 @@
     line-height: @bar_line_height;
 
     margin: 0 0 2px 0;
-
-    touch-action: pan-y; /* Fallback for Firefox, which doesn't support pinch-zoom */
-    touch-action: pan-y pinch-zoom;
 }
 
 .list-article-inner {

--- a/assets/widgets/ListArticle.less
+++ b/assets/widgets/ListArticle.less
@@ -12,6 +12,9 @@
     line-height: @bar_line_height;
 
     margin: 0 0 2px 0;
+
+    touch-action: pan-y; /* Fallback for Firefox, which doesn't support pinch-zoom */
+    touch-action: pan-y pinch-zoom;
 }
 
 .list-article-inner {


### PR DESCRIPTION
While it seemed to work on a Linux machine with a Wacom tablet, this
doesn't actually work in Firefox on a Windows 10 tablet with
a multi-touch screen. The event stream is cancelled almost immediately
as the browser interprets it as a potential scroll gesture. While it
might be possible to deal with this via liberal application of
JavaScript, I think that it is more important for scrolling to remain
performant than to support this swipe gesture.