### PR TITLE
Quick and dirty content-encoding: gzip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ webpack-prod:
 	@echo "WEBPACK"
 	$(V)NODE_ENV=production $(WEBPACK) --bail --profile --json > webpack-stats.json
 	$(V)if grep -q propTypes yarrharr/static/main.*.js; then echo "ERROR: propTypes found in bundle. Please remove them."; exit 1; fi
+	$(V)gzip -9 yarrharr/static/*.js yarrharr/static/*.css yarrharr/static/*.ico yarrharr/static/*.map
 
 release: webpack-prod
 	rm -rf build/lib build/bdist.*  # Work around https://github.com/pypa/wheel/issues/147

--- a/yarrharr/templatetags/static_glob.py
+++ b/yarrharr/templatetags/static_glob.py
@@ -71,7 +71,7 @@ def newest_static(pattern):
     assert '/' not in pattern  # don't support subdirectories
     name, mtime = None, None
     for fn in os.listdir(_static_dir):  # *sigh* need Python 3 for scandir...
-        if not fnmatch.fnmatchcase(fn, pattern):
+        if not (fnmatch.fnmatchcase(fn, pattern) or fnmatch.fnmatchcase(fn, pattern + '.gz')):
             continue
 
         s = os.stat(os.path.join(_static_dir, fn))

--- a/yarrharr/templatetags/static_glob.py
+++ b/yarrharr/templatetags/static_glob.py
@@ -58,8 +58,10 @@ def newest_static(pattern):
     This combines with a Webpack output file pattern that incorporates a hash
     of the file contents to ensure that the browser always receives the latest
     file without sending cache-busting headers. Discarding all but the newest
-    files is necessary because Webpack's watch mode doesn't clear files from
-    the output directory (``CleanWebpackPlugin`` doesn't operate).
+    files is necessary because Webpack's watch mode (used in development)
+    doesn't clear files from the output directory (``CleanWebpackPlugin``
+    doesn't operate). In production the mtime checking is a no-op, as there is
+    exactly one file which matches the pattern.
 
     :param str pattern: fnmatch (glob) pattern -- see :mod:`fnmatch`
     :returns: name of the file with the greatest modification time in the directory


### PR DESCRIPTION
static.File will automatically serve a .gz file with `content-encoding: gzip`. Brotli would be better, but would require teaching static.File to do content negotiation. The implementation looks pretty hairy so let's not.

Closes #270.