### PR TITLE
Set Cache-Control: immutable on static assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ matrix:
             - icoutils
             - python-scour
             - optipng
-            - brotli

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ matrix:
       script:
         - tox -e py36-lint
         - tox -e py36-test
-    - language: node_js
-      install: "pip install tox"
+    - language: python
+      python: "3.6"
+      install:
+        - "pip install tox"
+        - "nvm install"
       script:
         - npm install
         - make webpack-prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - tox -e py36-lint
         - tox -e py36-test
     - language: node_js
+      install: "pip install tox"
       script:
         - npm install
         - make webpack-prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ matrix:
             - icoutils
             - python-scour
             - optipng
+            - brotli

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,17 @@ WEBPACK ?= node_modules/.bin/webpack
 # Run ``make V=`` to see the commands run.
 V := @
 
+COMPRESS_FILES := \
+	yarrharr/static/*.js \
+	yarrharr/static/*.css \
+	yarrharr/static/*.ico
+
 webpack-prod:
 	@echo "WEBPACK"
 	$(V)NODE_ENV=production $(WEBPACK) --bail --profile --json > webpack-stats.json
 	$(V)if grep -q propTypes yarrharr/static/main.*.js; then echo "ERROR: propTypes found in bundle. Please remove them."; exit 1; fi
-	$(V)gzip -9 yarrharr/static/*.js yarrharr/static/*.css yarrharr/static/*.ico yarrharr/static/*.map
+	$(V)brotli --best --keep --suffix .br $(COMPRESS_FILES)
+	$(V)gzip -9 $(COMPRESS_FILES) yarrharr/static/*.map
 
 release: webpack-prod
 	rm -rf build/lib build/bdist.*  # Work around https://github.com/pypa/wheel/issues/147

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,12 @@ WEBPACK ?= node_modules/.bin/webpack
 # Run ``make V=`` to see the commands run.
 V := @
 
-COMPRESS_FILES := \
-	yarrharr/static/*.css \
-	yarrharr/static/*.ico \
-	yarrharr/static/*.js \
-	yarrharr/static/*.svg
 
 webpack-prod:
 	@echo "WEBPACK"
 	$(V)NODE_ENV=production $(WEBPACK) --bail --profile --json > webpack-stats.json
 	$(V)if grep -q propTypes yarrharr/static/main-*.js; then echo "ERROR: propTypes found in bundle. Please remove them."; exit 1; fi
-	$(V)for f in  $(COMPRESS_FILES); do brotli --quality 11 --input $$f --output $$f.br; done
-	$(V)gzip -9 $(COMPRESS_FILES) yarrharr/static/*.map
+	$(V)tox -e compress
 
 release: webpack-prod
 	rm -rf build/lib build/bdist.*  # Work around https://github.com/pypa/wheel/issues/147

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,16 @@ WEBPACK ?= node_modules/.bin/webpack
 V := @
 
 COMPRESS_FILES := \
-	yarrharr/static/*.js \
 	yarrharr/static/*.css \
-	yarrharr/static/*.ico
+	yarrharr/static/*.ico \
+	yarrharr/static/*.js \
+	yarrharr/static/*.svg
 
 webpack-prod:
 	@echo "WEBPACK"
 	$(V)NODE_ENV=production $(WEBPACK) --bail --profile --json > webpack-stats.json
-	$(V)if grep -q propTypes yarrharr/static/main.*.js; then echo "ERROR: propTypes found in bundle. Please remove them."; exit 1; fi
-	$(V)brotli --best --keep --suffix .br $(COMPRESS_FILES)
+	$(V)if grep -q propTypes yarrharr/static/main-*.js; then echo "ERROR: propTypes found in bundle. Please remove them."; exit 1; fi
+	$(V)for f in  $(COMPRESS_FILES); do brotli --quality 11 --input $$f --output $$f.br; done
 	$(V)gzip -9 $(COMPRESS_FILES) yarrharr/static/*.map
 
 release: webpack-prod

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [1.0 milestone](https://github.com/twm/yarrharr/milestone/1) tracks whether 
 ## Development
 
 Yarrharr is a Python application, but also a modern web app, so its dependencies are numerous.
-The following steps work on Ubuntu 14.04 and 16.04; some modification may be necessary for Debian.
+The following steps work on Ubuntu 16.04; some modification may be necessary for Debian.
 
 The [conventions document](./conventions.md) describes some idioms used in the codebase.
 
@@ -27,7 +27,7 @@ The [conventions document](./conventions.md) describes some idioms used in the c
 
 Grab the build dependencies with:
 
-    $ sudo apt-get install inkscape icoutils git python-scour optipng \
+    $ sudo apt-get install brotli inkscape icoutils git python-scour optipng \
                            python-dev build-essential
 
 Install [install pip](https://pip.pypa.io/en/latest/installing/#get-pip), then install [Tox](http://tox.readthedocs.org/en/latest/).

--- a/bin/compress-prod.py
+++ b/bin/compress-prod.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+# Copyright © 2018 Tom Most <twm@freecog.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this Program, or any covered work, by linking or
+# combining it with OpenSSL (or a modified version of that library),
+# containing parts covered by the terms of the OpenSSL License, the
+# licensors of this Program grant you additional permission to convey
+# the resulting work.  Corresponding Source for a non-source form of
+# such a combination shall include the source code for the parts of
+# OpenSSL used as well as that of the covered work.
+"""
+Generate .gz and .br versions of the files in yarrharr/static
+"""
+from pathlib import Path
+
+import zopfli.gzip
+import brotli
+
+static_dir = Path('yarrharr/static')
+src_files = []
+for pattern in ('*.js', '*.css', '*.svg', '*.ico', '*.map'):
+    src_files.extend(static_dir.glob(pattern))
+src_files.sort()
+
+print("ORIGINAL   ZOPFLI    (.gz)  BROTLI   (.br)  FILE")
+print("---------  ---------------  --------------  ------------------------------------------")
+
+for path in src_files:
+    buf = path.read_bytes()
+
+    gz_path = path.with_suffix(path.suffix + '.gz')
+    gz = zopfli.gzip.compress(buf)
+    gz_path.write_bytes(gz)
+
+    br_path = path.with_suffix(path.suffix + '.br')
+    br = brotli.compress(buf, quality=11)
+    br_path.write_bytes(br)
+
+    base_size = len(buf)
+    gz_size = len(gz)
+    gz_pct = gz_size / base_size
+    br_size = len(br)
+    br_pct = br_size / base_size
+    print("{base_size:>9,d}  {gz_size:>9,d} {gz_pct:>5.0%} {br_size:>9,d} {br_pct:>5.0%}  {path.name}".format_map(locals()))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'attrs == 18.1.0',
         'Django ~= 2.0.1',
-        'Twisted[tls] == 18.7.0',
+        'Twisted[tls,http2] == 18.7.0',
         'treq >= 17.8.0',
         'pytz',
         # We are (hopefully temporarily) using a fork of feedparser as the

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'attrs == 18.1.0',
         'Django ~= 2.0.1',
         'Twisted[tls] ~= 18.4.0',
-        'treq ~= 17.8.0',
+        'treq >= 17.8.0',
         'pytz',
         # We are (hopefully temporarily) using a fork of feedparser as the
         # maintainer is MIA.

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,15 @@ basepython = python3
 usedevelop = true
 commands = {posargs:django-admin --help}
 
+[testenv:compress]
+description = Compress static assets for production deployment
+basepython = python3.6
+skip_install = true
+deps =
+    brotli
+    zopfli
+commands = {envpython} {toxinidir}/bin/compress-prod.py
+
 [flake8]
 ignore = E128
 exclude = yarrharr/wsgi.py,yarrharr/migrations/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,15 @@ minversion = 2.5.0
 [testenv]
 usedevelop = true
 deps =
+; The tests currently require a treq with https://github.com/twisted/treq/pull/225
+    test: https://github.com/twisted/treq/archive/0041d5d78a1b69a58b0f59c752d38be0335fe98e.zip
     lint: flake8 == 3.0.4
 setenv =
     YARRHARR_CONF={toxinidir}/yarrharr/tests/test_config.ini
     DJANGO_SETTINGS_MODULE=yarrharr.settings
     PYTHONWARNINGS=all,ignore::ImportWarning,ignore::DeprecationWarning:site
+; This must remain disabled due to https://github.com/twisted/treq/issues/226
+;   POISON_REACTOR=yes
 commands =
     test: django-admin test -v2 yarrharr.tests
     test: django-admin makemigrations --dry-run --check

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -169,7 +169,7 @@ module.exports = {
             use: [{
                 loader: 'file-loader',
                 options: {
-                    name: '[name].[hash].[ext]',
+                    name: '[name]-[hash].[ext]',
                 },
             }],
         }],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,6 +72,7 @@ function processFavicon(svgSource) {
 function scourFavicon(file) {
     const outfile = `${file}.scour.svg`;
     const args = [
+        '/usr/bin/scour',
         '-i', file,
         '-o', outfile,
         '--indent=none',
@@ -79,7 +80,11 @@ function scourFavicon(file) {
         '--enable-id-stripping',
         '--shorten-ids',
     ];
-    return execFile('scour', args).then(_ => readFile(outfile)).then(bufferToAsset);
+    // Travis seems to rewire /usr/bin/python to whatever version of Python is
+    // specified in the job, so it is Python 3 there. However, the scour
+    // executable installed by apt is Python 2.7 only, so we must explicitly
+    // run python2.7.
+    return execFile('python2.7', args).then(_ => readFile(outfile)).then(bufferToAsset);
 }
 
 function rasterizeFavicon(file) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ const MinifyPlugin = require("babel-minify-webpack-plugin");
 const production = process.env.NODE_ENV === 'production';
 
 const extractLESS = new ExtractTextPlugin({
-    filename: "[name].[contenthash:base32:20].css",
+    filename: "[name]-[contenthash:base32:20].css",
     // disable: production,
 });
 
@@ -31,7 +31,7 @@ const plugins = [
             compiler.plugin('emit', (compilation, callback) => {
                 const [filename, asset] = function() {
                     for (let filename in compilation.assets) {
-                        if (/^icon\.[^.]+\.svg$/.test(filename)) {
+                        if (/^icon-[^.]+\.svg$/.test(filename)) {
                             return [filename, compilation.assets[filename]];
                         }
                     }
@@ -176,7 +176,7 @@ module.exports = {
     },
     output: {
         path: path.join(__dirname, 'yarrharr/static'),
-        filename: '[name].[hash].js',
+        filename: '[name]-[hash].js',
     },
     plugins: plugins,
     devtool: 'source-map',

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -163,8 +163,8 @@ class Static(Resource):
 
     In development, the files are served uncompressed and named like so::
 
-        main.afffb00fd22ca3ce0250.js
-        main.afffb00fd22ca3ce0250.js.map
+        main-afffb00fd22ca3ce0250.js
+        main-afffb00fd22ca3ce0250.js.map
 
     The second dot-delimited section is a hash of the file's contents or source
     material. As the filename changes each time the content does, these files
@@ -176,10 +176,10 @@ class Static(Resource):
     variant is present (we just serve the gzip version, regardless of what the
     browser's Accept-Encoding header says). For example::
 
-        main.afffb00fd22ca3ce0250.js.br
-        main.afffb00fd22ca3ce0250.js.map.br
-        main.afffb00fd22ca3ce0250.js.gz
-        main.afffb00fd22ca3ce0250.js.map.gz
+        main-afffb00fd22ca3ce0250.js.br
+        main-afffb00fd22ca3ce0250.js.map.br
+        main-afffb00fd22ca3ce0250.js.gz
+        main-afffb00fd22ca3ce0250.js.map.gz
 
     The actual serving of the files is done by `twisted.web.static.File`, which
     is fancy and supports range requests, conditional gets, etc.

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -238,6 +238,7 @@ class Static(Resource):
         if file is None:
             file = self._file(self._dir.child(path), type)
 
+        request.setHeader(b'Vary', b'accept-encoding')
         request.setHeader(b'Cache-Control', b'public, max-age=31536000, immutable')
         return file
 

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -190,8 +190,8 @@ class Static(Resource):
     _dir = FilePath(settings.STATIC_ROOT)
     _validName = re.compile(br'^[a-zA-Z0-9]+-[a-zA-Z0-9]+(\.[a-z]+)+$')
     # TODO: Check the spec to see if these should be case-insensitive.
-    _brToken = re.compile(br'(:?^|[\s,])br(:?$|\s,])')
-    _gzToken = re.compile(br'(:?^|[\s,])(:?x-)?gzip(:?$|\s,])')
+    _brToken = re.compile(br'(:?^|[\s,])br(:?$|[\s,])')
+    _gzToken = re.compile(br'(:?^|[\s,])(:?x-)?gzip(:?$|[\s,])')
     _contentTypes = {
         b'.js': 'application/javascript',
         b'.css': 'text/css',

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -172,9 +172,7 @@ class Static(Resource):
     `Cache-Control`_ header.
 
     In production, each file has two pre-compressed variants: one with
-    a ``.gz`` extension, and one with a ``.br`` extension. No uncompressed
-    variant is present (we just serve the gzip version, regardless of what the
-    browser's Accept-Encoding header says). For example::
+    a ``.gz`` extension, and one with a ``.br`` extension. For example::
 
         main-afffb00fd22ca3ce0250.js.br
         main-afffb00fd22ca3ce0250.js.map.br
@@ -184,16 +182,12 @@ class Static(Resource):
     The actual serving of the files is done by `twisted.web.static.File`, which
     is fancy and supports range requests, conditional gets, etc.
 
-    We also automatically set the `SourceMap`_ header for requests to ``.css``
-    and ``.js`` files.
-
     .. note::
 
-        Several features used here are gated to HTTPS origins only:
+        Several features used here are only available to HTTPS origins.
         Cache-Control: immutable and Brotli compression both are in Firefox.
 
     .. _cache-control: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-    .. _sourcemap: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/SourceMap
     """
     _dir = FilePath(settings.STATIC_ROOT)
     _validName = re.compile(br'^[a-zA-Z0-9]+\.[a-zA-Z0-9]+(\.[a-z]+)+$')
@@ -214,9 +208,6 @@ class Static(Resource):
             return File(gz.path)
 
         request.setHeader(b'Cache-Control', b'public, max-age=31536000, immutable')
-
-        if path.endswith((b'.js', b'.css')):
-            request.setHeader(b'SourceMap', b'./' + path + b'.map')
 
         return File(self._dir.child(path).path)
 

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -196,8 +196,8 @@ class Static(Resource):
         b'.js': 'application/javascript',
         b'.css': 'text/css',
         b'.map': 'application/octet-stream',
-        b'.ico': '',  # TODO
-        b'.svg': '',  # TODO
+        b'.ico': 'image/x-icon',
+        b'.svg': 'image/svg+xml',
         b'.png': 'image/png',
     }
 

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -189,8 +189,9 @@ class Static(Resource):
     """
     _dir = FilePath(settings.STATIC_ROOT)
     _validName = re.compile(br'^[a-zA-Z0-9]+-[a-zA-Z0-9]+(\.[a-z]+)+$')
-    _brToken = re.compile(br'(:?^|[\s,])br(:?$|\s,])', re.I)
-    _gzToken = re.compile(br'(:?^|[\s,])(:?x-)?gzip(:?$|\s,])', re.I)
+    # TODO: Check the spec to see if these should be case-insensitive.
+    _brToken = re.compile(br'(:?^|[\s,])br(:?$|\s,])')
+    _gzToken = re.compile(br'(:?^|[\s,])(:?x-)?gzip(:?$|\s,])')
     _contentTypes = {
         b'.js': 'application/javascript',
         b'.css': 'text/css',

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -192,12 +192,12 @@ class Static(Resource):
     _brToken = re.compile(br'(:?^|[\s,])br(:?$|\s,])', re.I)
     _gzToken = re.compile(br'(:?^|[\s,])(:?x-)?gzip(:?$|\s,])', re.I)
     _contentTypes = {
-        '.js': 'application/javascript',
-        '.css': 'text/css',
-        '.map': 'application/octet-stream',
-        '.ico': '',  # TODO
-        '.svg': '',  # TODO
-        '.png': 'image/png',
+        b'.js': 'application/javascript',
+        b'.css': 'text/css',
+        b'.map': 'application/octet-stream',
+        b'.ico': '',  # TODO
+        b'.svg': '',  # TODO
+        b'.png': 'image/png',
     }
 
     def _file(self, path, type, encoding=None):
@@ -217,8 +217,9 @@ class Static(Resource):
         if not self._validName.match(path):
             return NoResource("Not found.")
 
+        ext = path[path.rindex(b'.'):]
         try:
-            type = self._contentTypes[path[path.rindex(b'.') - 1:]]
+            type = self._contentTypes[ext]
         except KeyError:
             return NoResource("Unknown type.")
 

--- a/yarrharr/templates/base.html
+++ b/yarrharr/templates/base.html
@@ -6,13 +6,13 @@
         <title>{% block title %}{{ title|default:"Yarrharr" }}{% endblock %}</title>
         {# XXX Does user-scalable=no do anything anymore? #}
         <meta name="viewport" content="width=device-width, user-scalable=no">
-        <link rel="shortcut icon" sizes="16x16 24x24 32x32 48x48 64x64" href="{% static 'icon.*.ico'|newest_static %}">
-        <link rel="icon" sizes="152x152" type="image/png" href="{% static 'icon.*.png'|newest_static %}">
-        <link rel="icon" sizes="any" type="image/svg+xml" href="{% static 'icon.*.svg'|newest_static %}">
-        <link rel="apple-touch-icon-precomposed" type="image/png" href="{% static 'icon.*.png'|newest_static %}">
-        <link rel="stylesheet" type="text/css" href="{% static 'main.*.css'|newest_static %}">
-        <script src="{% static 'vendor.*.js'|newest_static %}" defer></script>
-        <script src="{% static 'main.*.js'|newest_static %}" defer></script>
+        <link rel="shortcut icon" sizes="16x16 24x24 32x32 48x48 64x64" href="{% static 'icon-*.ico'|newest_static %}">
+        <link rel="icon" sizes="152x152" type="image/png" href="{% static 'icon-*.png'|newest_static %}">
+        <link rel="icon" sizes="any" type="image/svg+xml" href="{% static 'icon-*.svg'|newest_static %}">
+        <link rel="apple-touch-icon-precomposed" type="image/png" href="{% static 'icon-*.png'|newest_static %}">
+        <link rel="stylesheet" type="text/css" href="{% static 'main-*.css'|newest_static %}">
+        <script src="{% static 'vendor-*.js'|newest_static %}" defer></script>
+        <script src="{% static 'main-*.js'|newest_static %}" defer></script>
     </head>
     <body>
         <main role=main>

--- a/yarrharr/templates/login.html
+++ b/yarrharr/templates/login.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <div class="login-page">
-    <h1><img width="64" height="64" src="{% static 'icon.*.svg'|newest_static %}" alt="">Yarrharr</h1>
+    <h1><img width="64" height="64" src="{% static 'icon-*.svg'|newest_static %}" alt="">Yarrharr</h1>
 
     <form method=post action="{% url 'login' %}" class="small-form">
         {{ form.as_p }}

--- a/yarrharr/templatetags/static_glob.py
+++ b/yarrharr/templatetags/static_glob.py
@@ -62,6 +62,10 @@ def newest_static(pattern):
     doesn't operate). In production the mtime checking is a no-op, as there is
     exactly one file which matches the pattern.
 
+    Matching is also done with additional ``.gz`` and ``.br`` extensions. These
+    are stripped in the return value, as `yarrharr.application.Static` does not
+    permit them.
+
     :param str pattern: fnmatch (glob) pattern -- see :mod:`fnmatch`
     :returns: name of the file with the greatest modification time in the directory
     :raises: :exc:`NoStaticMatch` when no file matching the pattern exists
@@ -75,13 +79,17 @@ def newest_static(pattern):
 
         if not (
             fnmatch.fnmatchcase(entry.name, pattern) or
-            fnmatch.fnmatchcase(entry.name, pattern + '.gz')
+            fnmatch.fnmatchcase(entry.name, pattern + '.gz') or
+            fnmatch.fnmatchcase(entry.name, pattern + '.br')
         ):
             continue
 
         s = entry.stat()
         if mtime is None or s.st_mtime > mtime:
-            name = entry.name
+            if entry.name.endswith(('.br', '.gz')):
+                name = entry.name[:-3]
+            else:
+                name = entry.name
             mtime = s.st_mtime
 
     if name is None:

--- a/yarrharr/tests/__init__.py
+++ b/yarrharr/tests/__init__.py
@@ -1,0 +1,53 @@
+# Copyright © 2018 Tom Most <twm@freecog.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this Program, or any covered work, by linking or
+# combining it with OpenSSL (or a modified version of that library),
+# containing parts covered by the terms of the OpenSSL License, the
+# licensors of this Program grant you additional permission to convey
+# the resulting work.  Corresponding Source for a non-source form of
+# such a combination shall include the source code for the parts of
+# OpenSSL used as well as that of the covered work.
+
+import os
+
+from twisted.internet.interfaces import IReactorTime
+from zope.interface import implementer
+
+
+@implementer(IReactorTime)
+class PoisonReactor(object):
+    """
+    A reactor which answers all requests with a `NotImplementedError`. It
+    exists only to be importable as ``from twisted.internet import reactor`` to
+    make it easier to find code which uses the global reactor.
+    """
+    # We must define callLater because the bound method is plucked off by
+    # twisted.web.http.HTTPFActory.buildProtocol().
+    def callLater(self, delay, callable, *args, **kw):
+        raise NotImplementedError
+
+    def seconds(self):
+        raise NotImplementedError
+
+    def getDelayedCalls(self):
+        raise NotImplementedError
+
+
+if os.environ.get('POISON_REACTOR'):
+    from twisted.internet.main import installReactor
+    installReactor(PoisonReactor())

--- a/yarrharr/tests/test_application.py
+++ b/yarrharr/tests/test_application.py
@@ -174,7 +174,7 @@ class StaticTests(SynchronousTestCase):
 
         self.assertResponse(
             self.treq.head('http://x/a-bcd.js', headers={
-                'accept-encoding': 'gzip',
+                'accept-encoding': ['gzip'],
             }),
             content_length='3',
             content_type='application/javascript',
@@ -182,7 +182,7 @@ class StaticTests(SynchronousTestCase):
         )
         self.assertResponse(
             self.treq.head('http://x/a-bcd.js', headers={
-                'accept-encoding': 'x-gzip, deflate',
+                'accept-encoding': ['x-gzip, deflate'],
             }),
             content_length='3',
             content_type='application/javascript',
@@ -190,7 +190,7 @@ class StaticTests(SynchronousTestCase):
         )
         self.assertResponse(
             self.treq.head('http://x/a-bcd.js', headers={
-                'accept-encoding': 'deflate,gzip',
+                'accept-encoding': ['deflate,gzip'],
             }),
             content_length='3',
             content_type='application/javascript',

--- a/yarrharr/tests/test_application.py
+++ b/yarrharr/tests/test_application.py
@@ -133,36 +133,75 @@ class StaticTests(SynchronousTestCase):
                          response.headers.getRawHeaders('content-encoding', ['']))
         self.assertEqual(['accept-encoding'], response.headers.getRawHeaders('vary'))
 
-    def test_raw_js(self):
+    def test_serve_js(self):
         """
         JS is served as application/javascript, immutable.
         """
         self.dir.child('foo-xxyy.js').touch()
-        self.dir.child('foo-xxyy.js.map').touch()
 
         self.assertResponse(
             self.agent.request(b'HEAD', b'http://x/foo-xxyy.js'),
             content_type='application/javascript',
         )
-        self.assertResponse(
-            self.agent.request(b'HEAD', b'http://x/foo-xxyy.js.map'),
-            content_type='application/octet-stream',
-        )
 
-    def test_raw_css(self):
+    def test_serve_css(self):
         """
         CSS is served as text/css, immutable.
         """
         self.dir.child('bar-zz99.css').touch()
-        self.dir.child('bar-zz99.css.map').touch()
 
         self.assertResponse(
             self.agent.request(b'HEAD', b'http://x/bar-zz99.css'),
             content_type='text/css',
         )
+
+    def test_serve_map(self):
+        """
+        Source map files are served as application/octet-stream, immutable.
+        """
+        self.dir.child('bar-zz99.css.map').touch()
+        self.dir.child('foo-xxyy.js.map').touch()
+
+        self.assertResponse(
+            self.agent.request(b'HEAD', b'http://x/foo-xxyy.js.map'),
+            content_type='application/octet-stream',
+        )
         self.assertResponse(
             self.agent.request(b'HEAD', b'http://x/bar-zz99.css.map'),
             content_type='application/octet-stream',
+        )
+
+    def test_serve_png(self):
+        """
+        PNG images are served as image/png, immutable.
+        """
+        self.dir.child('img-barq.png').touch()
+
+        self.assertResponse(
+            self.agent.request(b'HEAD', b'http://x/img-barq.png'),
+            content_type='image/png',
+        )
+
+    def test_serve_svg(self):
+        """
+        PNG images are served as image/svg+xml, immutable.
+        """
+        self.dir.child('img-blif.svg').touch()
+
+        self.assertResponse(
+            self.agent.request(b'HEAD', b'http://x/img-blif.svg'),
+            content_type='image/svg+xml',
+        )
+
+    def test_serve_ico(self):
+        """
+        ICO images are served as image/x-icon, immutable.
+        """
+        self.dir.child('img-bizf.ico').touch()
+
+        self.assertResponse(
+            self.agent.request(b'HEAD', b'http://x/img-bizf.ico'),
+            content_type='image/x-icon',
         )
 
     def test_accept_gzip(self):

--- a/yarrharr/tests/test_application.py
+++ b/yarrharr/tests/test_application.py
@@ -107,7 +107,7 @@ class StaticTests(SynchronousTestCase):
         is never started under the Django test runner.
 
     At least, that's what I *think* is going on. There is other stuff touching
-    the global reactor too. See treq #225.
+    the global reactor too. See treq #225 and #226.
 
     It's an ugly hack, but we rely on the Content-Length header to tell if the
     right file is being served.
@@ -133,6 +133,7 @@ class StaticTests(SynchronousTestCase):
                          response.headers.getRawHeaders('content-type', ['']))
         self.assertEqual([content_encoding],
                          response.headers.getRawHeaders('content-encoding', ['']))
+        self.assertEqual(['accept-encoding'], response.headers.getRawHeaders('vary'))
 
     def test_raw_js(self):
         """

--- a/yarrharr/tests/test_fetch.py
+++ b/yarrharr/tests/test_fetch.py
@@ -84,9 +84,10 @@ def examples():
 @attr.s
 class StaticResource(object):
     """
-    `StaticLastModifiedResource` implements :class:`~twisted.web.resource.IResource`.
+    `StaticResource` implements :class:`~twisted.web.resource.IResource`.
     It produces a static response for all requests.
     """
+    # FIXME: Can't this be replaced with static.Data?
     content = attr.ib()
     content_type = attr.ib(default=b'application/xml')
 


### PR DESCRIPTION
Unfortunately this is useless in dev until I get self-signed certs set up
because Cache-Control: immutable is gated behind HTTPS.

Marking this [WIP] because:

* [x] Unit tests
* [x] Generate .br assets
* [x] Manual testing on HTTPS sites
* [x] SourceMap header is triggering a console warning in Firefox. Revert it?

Closes #274.