### PR TITLE
404 /favicon.ico without logging an error

### DIFF
--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -45,7 +45,7 @@ from twisted.logger import FilteringLogObserver, ILogFilterPredicate, PredicateR
 from twisted.web.wsgi import WSGIResource
 from twisted.web.server import Site
 from twisted.web.static import File
-from twisted.web.resource import Resource, NoResource
+from twisted.web.resource import ErrorPage, Resource, NoResource
 from twisted.internet.endpoints import serverFromString
 from twisted.python.filepath import FilePath
 from zope.interface import implementer
@@ -288,6 +288,9 @@ class Root(FallbackResource):
 
         self.putChild(b'csp-report', CSPReportLogger())
         self.putChild(b'static', Static())
+        # Handle requests for /favicon.ico at the Twisted level so that they
+        # don't make it down to Django, which logs 404s as errors:
+        self.putChild(b'favicon.ico', ErrorPage(404, 'Not Found', ''))
 
     def getChildWithDefault(self, name, request):
         # Disable the Referer header in some browsers. This is complemented by

--- a/yarrharr/tests/test_application.py
+++ b/yarrharr/tests/test_application.py
@@ -337,6 +337,16 @@ class RootTests(SynchronousTestCase):
 
         self.assertEqual(200, response.code)
 
+    def test_favicon_404(self):
+        """
+        Requests to ``/favicon.ico`` produce a 404 error.
+        """
+        treq = self.mkTreq()
+
+        response = self.successResultOf(treq.get('http://127.0.0.1:8888/favicon.ico'))
+
+        self.assertEqual(404, response.code)
+
 
 class FormatForSystemdTests(SynchronousTestCase):
     def test_logger_namespace(self):


### PR DESCRIPTION
Closes #269.