### PR TITLE
Add 'proxied' configuration option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {test,lint}-py35
+envlist = {test,lint}-py37
 minversion = 2.5.0
 
 [testenv]

--- a/yarrharr/conf.py
+++ b/yarrharr/conf.py
@@ -47,7 +47,8 @@ server_endpoint = tcp:8888:interface=127.0.0.1
 ; effect.
 external_url = http://127.0.0.1:8888
 ; Is Yarrharr deployed behind a reverse proxy such as Apache, nginx, or
-; haproxy? Set to "x-forwarded-host" to respect that header.
+; haproxy? Set to "x-forwarded" to respect the X-Forwarded-Host and
+; X-Forwarded-Port headers.
 proxied = no
 static_root = /var/lib/yarrharr/static/
 ; URL of the files at static_root.  Normally this should only be overridden in

--- a/yarrharr/conf.py
+++ b/yarrharr/conf.py
@@ -46,8 +46,8 @@ server_endpoint = tcp:8888:interface=127.0.0.1
 ; Must be kept in sync with server_endpoint, or may vary if proxying is in
 ; effect.
 external_url = http://127.0.0.1:8888
-; Is Yarrharr deployed behind a reverse proxy such as Apache or nginx?
-; If so, it will obey the X-Forwarded-For header.
+; Is Yarrharr deployed behind a reverse proxy such as Apache, nginx, or
+; haproxy? Set to "x-forwarded-host" to respect that header.
 proxied = no
 static_root = /var/lib/yarrharr/static/
 ; URL of the files at static_root.  Normally this should only be overridden in
@@ -134,11 +134,20 @@ def read_yarrharr_conf(files, namespace):
     if external_url.path != '':
         # Ensure that the URL doesn't contain a path, as some day we will
         # probably want to add the ability to add a prefix to the path.
-        msg = "external_url must not include path: remove {!r}".format(
-            external_url.path)
+        msg = "external_url must not include path: remove {!r}".format(external_url.path)
         raise ValueError(msg)
     namespace['ALLOWED_HOSTS'] = [external_url.hostname]
-    namespace['USE_X_FORWARDED_HOST'] = conf.getboolean('yarrharr', 'proxied')
+
+    # The proxied config is an enumeration to ensure it can be extended to
+    # support the Forwarded header (RFC 7239) in the future. We require expicit
+    # configuration rather than auto-detecting these headers because the
+    # frontend proxy *must* be configured to strip whatever header is in use,
+    # lest clients be able to forge it.
+    proxied = conf.get('yarrharr', 'proxied')
+    if proxied not in {'no', 'x-forwarded'}:
+        msg = "proxied must be 'no' or 'x-forwarded', not {!r}".format(proxied)
+        raise ValueError(msg)
+    namespace['USE_X_FORWARDED_HOST'] = proxied == 'x-forwarded'
 
     # Config for the Twisted production server.
     namespace['SERVER_ENDPOINT'] = conf.get('yarrharr', 'server_endpoint')

--- a/yarrharr/tests/test_conf.py
+++ b/yarrharr/tests/test_conf.py
@@ -108,6 +108,7 @@ class ConfTests(unittest.TestCase):
             'USE_I18N': True,
             'USE_L10N': True,
             'USE_TZ': True,
+            'USE_X_FORWARDED_HOST': False,
             'TIME_ZONE': 'UTC',
             'STATIC_ROOT': '/var/lib/yarrharr/static/',
             'STATIC_URL': '/static/',
@@ -134,6 +135,7 @@ class ConfTests(unittest.TestCase):
             ),
             'SESSION_ENGINE': 'django.contrib.sessions.backends.signed_cookies',
             'SESSION_COOKIE_HTTPONLY': True,
+            'SESSION_COOKIE_SECURE': False,
             'WSGI_APPLICATION': 'yarrharr.wsgi.application',
             'INSTALLED_APPS': (
                 'django.contrib.auth',
@@ -180,6 +182,7 @@ class ConfTests(unittest.TestCase):
             'USE_I18N': True,
             'USE_L10N': True,
             'USE_TZ': True,
+            'USE_X_FORWARDED_HOST': False,
             'TIME_ZONE': 'UTC',
             'STATIC_ROOT': 'yarrharr/static/',
             'STATIC_URL': '/static/',
@@ -207,6 +210,7 @@ class ConfTests(unittest.TestCase):
             ),
             'SESSION_ENGINE': 'django.contrib.sessions.backends.signed_cookies',
             'SESSION_COOKIE_HTTPONLY': True,
+            'SESSION_COOKIE_SECURE': False,
             'WSGI_APPLICATION': 'yarrharr.wsgi.application',
             'INSTALLED_APPS': (
                 'django.contrib.auth',


### PR DESCRIPTION
A partial solution to #308. This works at the Django level, so access log IPs will be wrong.