### PR TITLE
Mark CSRF token cookie secure

### DIFF
--- a/yarrharr/conf.py
+++ b/yarrharr/conf.py
@@ -200,6 +200,7 @@ def read_yarrharr_conf(files, namespace):
     namespace['SESSION_ENGINE'] = 'django.contrib.sessions.backends.signed_cookies'
     namespace['SESSION_COOKIE_HTTPONLY'] = True
     namespace['SESSION_COOKIE_SECURE'] = external_url.scheme == 'https'
+    namespace['CSRF_TOKEN_SECURE'] = external_url.scheme == 'https'
 
     namespace['WSGI_APPLICATION'] = 'yarrharr.wsgi.application'
 

--- a/yarrharr/tests/test_conf.py
+++ b/yarrharr/tests/test_conf.py
@@ -137,6 +137,7 @@ class ConfTests(unittest.TestCase):
             'SESSION_ENGINE': 'django.contrib.sessions.backends.signed_cookies',
             'SESSION_COOKIE_HTTPONLY': True,
             'SESSION_COOKIE_SECURE': False,
+            'CSRF_TOKEN_SECURE': False,
             'WSGI_APPLICATION': 'yarrharr.wsgi.application',
             'INSTALLED_APPS': (
                 'django.contrib.auth',
@@ -213,6 +214,7 @@ class ConfTests(unittest.TestCase):
             'SESSION_ENGINE': 'django.contrib.sessions.backends.signed_cookies',
             'SESSION_COOKIE_HTTPONLY': True,
             'SESSION_COOKIE_SECURE': False,
+            'CSRF_TOKEN_SECURE': False,
             'WSGI_APPLICATION': 'yarrharr.wsgi.application',
             'INSTALLED_APPS': (
                 'django.contrib.auth',
@@ -249,3 +251,5 @@ class ConfTests(unittest.TestCase):
         self.assertEqual(['f.q.d.n'], settings['ALLOWED_HOSTS'])
         self.assertEqual('tcp:8182:interface=127.0.0.1', settings['SERVER_ENDPOINT'])
         self.assertTrue(settings['USE_X_FORWARDED_HOST'])
+        self.assertTrue(settings['SESSION_COOKIE_SECURE'])
+        self.assertTrue(settings['CSRF_TOKEN_SECURE'])


### PR DESCRIPTION
Closes #318.