### PR TITLE
Toolbar work

### DIFF
--- a/assets/views/FeedView.js
+++ b/assets/views/FeedView.js
@@ -53,10 +53,10 @@ if (__debug__) {
  * SnapshotNav is displayed on article view pages to allow navigation to the
  * previous and next articles.
  *
- * +----+-----------+------+------+---------+----+
- * | <- |           | fave | read |         | -> |
- * | <- |           | fave | read |         | -> |
- * +----+-----------+------+------+---------+----+
+ * +-------------------+------+------+-----+-----+
+ * |                   | fave | read |  ↓  |  ↑  |
+ * |                   | fave | read |     |     |
+ * +-------------------+------+------+-----+-----+
  */
 class SnapshotNav extends React.PureComponent {
     render() {
@@ -67,6 +67,11 @@ class SnapshotNav extends React.PureComponent {
         const nextId = index < articleIds.length - 1 ? articleIds[index + 1] : null;
 
         return <div className="bar snapshot-nav">
+            <div className="expand">
+                {/* This occupies empty space at the left of the bar. */}
+            </div>
+            <FaveToggleLink className="square" articleId={articleId} fave={fave} onMarkArticlesFave={onMarkArticlesFave} />
+            <ReadToggleLink className="square" articleId={articleId} read={read} onMarkArticlesRead={onMarkArticlesRead} />
             {prevId ? renderLink({
                 className: "snapshot-nav-prev square",
                 title: "Go to previous article",
@@ -74,14 +79,6 @@ class SnapshotNav extends React.PureComponent {
                 children: <ArrowLeftIcon aria-hidden={true} />,
             }) : <span className="snapshot-nav-prev square" />}
             {this.props.icon ? <div className="snapshot-nav-icon square">{this.props.icon}</div> : null}
-            <div className="expand">
-                {/* This occupies empty space in the middle of the bar. */}
-            </div>
-            <FaveToggleLink className="square" articleId={articleId} fave={fave} onMarkArticlesFave={onMarkArticlesFave} />
-            <ReadToggleLink className="square" articleId={articleId} read={read} onMarkArticlesRead={onMarkArticlesRead} />
-            <div className="expand">
-                {/* This occupies empty space in the middle of the bar. */}
-            </div>
             {nextId ? renderLink({
                 className: "snapshot-nav-next square",
                 title: "Go to next article",

--- a/assets/views/FeedView.js
+++ b/assets/views/FeedView.js
@@ -11,7 +11,7 @@ import { ORDER_TAIL, ORDER_DATE } from 'actions.js';
 import { Tabs } from 'widgets/Tabs.js';
 import { GlobalBar, Header, HomeIconLink } from 'widgets/GlobalBar.js';
 import { Title } from 'widgets/Title.jsm';
-import { AscDescIcon, ArrowLeftIcon, ArrowRightIcon, EditIcon, GlobeIcon, FeedIcon, LabelIcon, ReturnIcon } from 'widgets/icons.js';
+import { AscDescIcon, PrevIcon, NextIcon, EditIcon, GlobeIcon, FeedIcon, LabelIcon, ReturnIcon } from 'widgets/icons.js';
 import { Article, LoadingArticle } from 'widgets/Article.js';
 import ListArticle from 'widgets/ListArticle.js';
 import { RootLink } from 'widgets/links.js';
@@ -76,14 +76,14 @@ class SnapshotNav extends React.PureComponent {
                 className: "snapshot-nav-prev square",
                 title: "Go to previous article",
                 articleId: prevId,
-                children: <ArrowLeftIcon aria-hidden={true} />,
+                children: <PrevIcon aria-hidden={true} />,
             }) : <span className="snapshot-nav-prev square" />}
             {this.props.icon ? <div className="snapshot-nav-icon square">{this.props.icon}</div> : null}
             {nextId ? renderLink({
                 className: "snapshot-nav-next square",
                 title: "Go to next article",
                 articleId: nextId,
-                children: <ArrowRightIcon aria-hidden={true} />,
+                children: <NextIcon aria-hidden={true} />,
             }) : <span className="snapshot-nav-next square" />}
         </div>
     }

--- a/assets/views/debug.jsm
+++ b/assets/views/debug.jsm
@@ -6,7 +6,7 @@ import { Title } from 'widgets/Title.jsm';
 import { Tabs } from 'widgets/Tabs.js';
 import { GlobalBar, Header, HomeIconLink } from 'widgets/GlobalBar.js';
 
-import { HomeIcon, GlobeIcon, LabelIcon, FeedIcon, ArrowLeftIcon, ArrowRightIcon, FollowIcon, OutboundIcon, EditIcon, GoFullscreenIcon, ExitFullscreenIcon, WideIcon, NarrowIcon, AscDescIcon, ReturnIcon } from 'widgets/icons.js';
+import { GlobeIcon, LabelIcon, FeedIcon, FollowIcon, OutboundIcon, EditIcon, GoFullscreenIcon, ExitFullscreenIcon, WideIcon, NarrowIcon, AscDescIcon, ReturnIcon, PrevIcon, NextIcon } from 'widgets/icons.js';
 import { FaveToggle, ReadToggle } from 'widgets/StateToggle.js';
 import { RootLink, InventoryLink, LabelListLink, AddFeedLink } from 'widgets/links.js';
 import './debug.less';
@@ -28,12 +28,10 @@ class DebugView extends React.PureComponent {
             <div className="debug-icons">
                 <h2>Icons</h2>
                 <p>
-                    Home <HomeIcon />
+                    {/*Home <HomeIcon />*/}
                     GlobeIcon <GlobeIcon />
                     Label <LabelIcon />
                     Feed <FeedIcon />
-                    Left <ArrowLeftIcon />
-                    Right <ArrowRightIcon />
                     Follow <FollowIcon />
                     Return <ReturnIcon />
                     Outbound <OutboundIcon />
@@ -54,14 +52,14 @@ class DebugView extends React.PureComponent {
                     Clickable <ToggleWrap>
                         {(value, onToggle) => <FaveToggle fave={value} onMarkArticlesFave={onToggle} articleId={1} />}
                     </ToggleWrap>
+                    Next <NextIcon />
+                    Prev <PrevIcon />
                 </p>
                 <p>
-                    <HomeIcon className="icon debug-icon-grid" />
+                    {/*<HomeIcon className="icon debug-icon-grid" />*/}
                     <GlobeIcon className="icon debug-icon-grid" />
                     <LabelIcon className="icon debug-icon-grid" />
                     <FeedIcon className="icon debug-icon-grid" />
-                    <ArrowLeftIcon className="icon debug-icon-grid" />
-                    <ArrowRightIcon className="icon debug-icon-grid" />
                     <FollowIcon className="icon debug-icon-grid" />
                     <ReturnIcon className="icon debug-icon-grid" />
                     <OutboundIcon className="icon debug-icon-grid" />
@@ -78,6 +76,8 @@ class DebugView extends React.PureComponent {
                     <ToggleWrap>
                         {(value, onToggle) => <FaveToggle fave={value} onMarkArticlesFave={onToggle} articleId={1} iconClass="icon debug-icon-grid" />}
                     </ToggleWrap>
+                    <NextIcon className="icon debug-icon-grid" />
+                    <PrevIcon className="icon debug-icon-grid" />
                 </p>
             </div>
         </React.Fragment>;

--- a/assets/widgets/GlobalBar.js
+++ b/assets/widgets/GlobalBar.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { setLayout, LAYOUT_NARROW, LAYOUT_WIDE } from 'actions.js';
 import { setTheme, THEME_LIGHT, THEME_DARK } from 'actions.js';
-import { HomeIcon, GoFullscreenIcon, ExitFullscreenIcon, NarrowIcon, WideIcon, SunIcon, MoonIcon } from 'widgets/icons.js';
+import { ReturnIcon, GoFullscreenIcon, ExitFullscreenIcon, NarrowIcon, WideIcon, SunIcon, MoonIcon } from 'widgets/icons.js';
 
 import { RootLink } from 'widgets/links.js';
 
@@ -146,7 +146,7 @@ export class FullscreenToggle extends React.Component {
 
 
 export function HomeIconLink(props) {
-    return <RootLink aria-label="Home" title="Go home" className="square"><HomeIcon aria-hidden={true} /></RootLink>;
+    return <RootLink aria-label="Home" title="Go home" className="square"><ReturnIcon aria-hidden={true} /></RootLink>;
 }
 
 

--- a/assets/widgets/ListArticle.js
+++ b/assets/widgets/ListArticle.js
@@ -12,16 +12,6 @@ function cancel(event) {
 }
 
 /**
- * The row must be slid at least this many pixels to trigger an action.
- */
-const MIN_SLIDE = 40;
-/**
- * The maximum number of pixels the row can be slid. It will stop moving after
- * this point.
- */
-const MAX_SLIDE = 70;
-
-/**
  * ListArticle displays article metadata in a few lines of text, along with
  * some links and buttons.
  *

--- a/assets/widgets/icons.js
+++ b/assets/widgets/icons.js
@@ -37,11 +37,11 @@ export function IconSprites(props) {
                 <path d={roof} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
                 <path d={"M7.5 17.5 l0 -7 l5 0 l0 7"} fill="none" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" strokeLinecap="round" />
             </symbol>
-            <symbol id="icon-arrow-right" viewBox="0 0 20 20">
-                <path d={largeArrow} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
+            <symbol id="icon-prev" viewBox="0 0 20 20">
+                <path d={largeArrow} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" transform={`rotate(-90, ${w / 2}, ${h / 2})`}  />
             </symbol>
-            <symbol id="icon-arrow-left" viewBox="0 0 20 20">
-                <path d={largeArrow} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" transform={`rotate(180, ${w / 2}, ${h / 2})`} />
+            <symbol id="icon-next" viewBox="0 0 20 20">
+                <path d={largeArrow} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" transform={`rotate(90, ${w / 2}, ${h / 2})`} />
             </symbol>
             <symbol id="icon-label" viewBox="0 0 20 20">
                 <circle cx="5" cy="5" r="1" fill="currentColor" stroke="none" />
@@ -95,8 +95,6 @@ function makeSpriteIcon(id, className = "icon") {
 }
 
 export const HomeIcon = makeSpriteIcon("#icon-home");
-export const ArrowRightIcon = makeSpriteIcon("#icon-arrow-right");
-export const ArrowLeftIcon = makeSpriteIcon("#icon-arrow-left");
 export const FeedIcon = makeSpriteIcon("#icon-feed");
 export const LabelIcon = makeSpriteIcon("#icon-label");
 export const OutboundIcon = makeSpriteIcon("#icon-outbound");
@@ -104,6 +102,8 @@ export const EditIcon = makeSpriteIcon("#icon-edit");
 export const HeartIcon = makeSpriteIcon("#icon-heart", "icon icon-heart");
 export const FollowIcon = makeSpriteIcon("#icon-follow");
 export const ReturnIcon = makeSpriteIcon("#icon-return");
+export const PrevIcon = makeSpriteIcon("#icon-prev");
+export const NextIcon = makeSpriteIcon("#icon-next");
 export const SunIcon = makeSpriteIcon("#icon-sun");
 export const MoonIcon = makeSpriteIcon("#icon-moon");
 

--- a/assets/widgets/icons.js
+++ b/assets/widgets/icons.js
@@ -32,11 +32,13 @@ export function IconSprites(props) {
 
     return <svg id="icon-sprites" aria-hidden={true}>
         <defs>
+            {/*
             <symbol id="icon-home" viewBox="0 0 20 20">
                 <path d={frame} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="square" />
                 <path d={roof} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
                 <path d={"M7.5 17.5 l0 -7 l5 0 l0 7"} fill="none" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" strokeLinecap="round" />
             </symbol>
+            */}
             <symbol id="icon-prev" viewBox="0 0 20 20">
                 <path d={largeArrow} fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" transform={`rotate(-90, ${w / 2}, ${h / 2})`}  />
             </symbol>
@@ -94,7 +96,7 @@ function makeSpriteIcon(id, className = "icon") {
     return component;
 }
 
-export const HomeIcon = makeSpriteIcon("#icon-home");
+// export const HomeIcon = makeSpriteIcon("#icon-home");
 export const FeedIcon = makeSpriteIcon("#icon-feed");
 export const LabelIcon = makeSpriteIcon("#icon-label");
 export const OutboundIcon = makeSpriteIcon("#icon-outbound");


### PR DESCRIPTION
* Replace the home icon with the return icon. This makes the icon to exit the list view and the article view consistent.
* Relocate all toolbar buttons to the bottom right. This is easier to use on a tablet because they are not spread across the entire screen. It is also easier on a phone (for the right-handed). This leaves the left side of the toolbar a rather forbidding black space. Perhaps the top and bottom toolbars could be consolidated in article view?
* Use up and down arrows for navigation between articles in the article view. This change mirrors the up/down of scrolling in the list view and means that there is only one type of horizontal arrow (the enter and return icons).