### PR TITLE
Deal with deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'attrs == 19.3.0',
         'Django >=2.1.3,<2.3.0',
         'Twisted[tls,http2] == 19.10.0',
+        # When updating treq remove the ignored deprecation warning in tox.ini [pytest].
         'treq >= 17.8.0',
         'pytz',
         # We are (hopefully temporarily) using a fork of feedparser as the

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         'attrs == 19.3.0',
         'Django >=2.1.3,<2.3.0',
         'Twisted[tls,http2] == 19.10.0',
-        # When updating treq remove the ignored deprecation warning in tox.ini [pytest].
         'treq >= 17.8.0',
         'pytz',
         # We are (hopefully temporarily) using a fork of feedparser as the

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ minversion = 2.5.0
 usedevelop = true
 deps =
 ; The tests currently require a treq with https://github.com/twisted/treq/pull/225
-    test: https://github.com/twisted/treq/archive/0041d5d78a1b69a58b0f59c752d38be0335fe98e.zip
+    test: https://github.com/twisted/treq/archive/2d28bf57c8695657ca04bc8c36924f17fcd286f4.zip
     test: pytest == 4.6.2
     test: pytest-twisted == 1.10
     test: pytest-django == 3.5.0
@@ -63,7 +63,5 @@ skip_glob = migrations/*.py
 filterwarnings=
     all
     ignore::ImportWarning
-    # Fixed in https://github.com/twisted/treq/pull/253
-    ignore:twisted.test.proto_helpers.MemoryReactorClock was deprecated in Twisted 19.7.0:DeprecationWarning:treq.testing
     # This is a Twisted bug, see https://twistedmatrix.com/trac/ticket/8227 and https://twistedmatrix.com/trac/ticket/8929
     ignore:Using readBody with a transport that does not have an abortConnection method:DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -63,5 +63,7 @@ skip_glob = migrations/*.py
 filterwarnings=
     all
     ignore::ImportWarning
-    # https://github.com/twisted/treq/pull/253
+    # Fixed in https://github.com/twisted/treq/pull/253
     ignore:twisted.test.proto_helpers.MemoryReactorClock was deprecated in Twisted 19.7.0:DeprecationWarning:treq.testing
+    # This is a Twisted bug, see https://twistedmatrix.com/trac/ticket/8227 and https://twistedmatrix.com/trac/ticket/8929
+    ignore:Using readBody with a transport that does not have an abortConnection method:DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -63,4 +63,5 @@ skip_glob = migrations/*.py
 filterwarnings=
     all
     ignore::ImportWarning
-    ignore::DeprecationWarning:site
+    # https://github.com/twisted/treq/pull/253
+    ignore:twisted.test.proto_helpers.MemoryReactorClock was deprecated in Twisted 19.7.0:DeprecationWarning:treq.testing

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
 setenv =
     YARRHARR_CONF={env:YARRHARR_CONF:{toxinidir}/yarrharr/tests/dev.ini}
     DJANGO_SETTINGS_MODULE=yarrharr.settings
-    PYTHONWARNINGS=all,ignore::ImportWarning,ignore::DeprecationWarning:site
     PYTHONDONTWRITEBYTECODE=yes
 ; This must remain disabled due to https://github.com/twisted/treq/issues/226
 ;   POISON_REACTOR=yes
@@ -59,3 +58,9 @@ use_parentheses = true
 line_length = 88
 skip = wsgi.py
 skip_glob = migrations/*.py
+
+[pytest]
+filterwarnings=
+    all
+    ignore::ImportWarning
+    ignore::DeprecationWarning:site

--- a/yarrharr/templatetags/static_glob.py
+++ b/yarrharr/templatetags/static_glob.py
@@ -39,7 +39,7 @@ register = template.Library()
 _static_dir = os.path.join(os.path.dirname(__file__), '../static')
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NoStaticMatch(Exception):
     pattern = attr.ib()
 


### PR DESCRIPTION
- [x] treq + twisted.internet.testing
- [x] readBody w/o abortConnection
- [x] cmp in static_glob