### PR TITLE
Set Webpack publicPath

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,7 @@ const config = {
     },
     output: {
         path: path.resolve(__dirname, 'yarrharr/static'),
+        publicPath: '/static/',
         filename: hotify('[name]-[contenthash].js'),
     },
     plugins: [

--- a/yarrharr/templates/base.html
+++ b/yarrharr/templates/base.html
@@ -28,7 +28,7 @@
             {% if user.is_authenticated %}
                 <p><a href="{% url 'home' %}">Home</a> ∙ <a href="{% url 'logout' %}">Log out</a>
             {% endif %}
-            <p>Yarrharr Feed Reader ∙ © 2013–2019 Tom Most ∙ GPLv3+ ∙ <a href="{% url 'about' %}">About</a> ∙ <a rel="noreferrer noopener" href="https://github.com/twm/yarrharr/issues/new">Report Issue</a>
+            <p>Yarrharr Feed Reader ∙ © 2013–2020 Tom Most ∙ GPLv3+ ∙ <a href="{% url 'about' %}">About</a> ∙ <a rel="noreferrer noopener" href="https://github.com/twm/yarrharr/issues/new">Report Issue</a>
         </footer>
 
         {% if debug %}


### PR DESCRIPTION
This fixes the path used to load the logotype and lettertype images in non-hot reloading builds.