### PR TITLE
Configure Dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I have disabled the dependabot-preview app. This PR adds a dependabot.yml file per https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates