### PR TITLE
Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: pip cache
       uses: actions/cache@v2
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: pip cache
       uses: actions/cache@v2

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = test, lint
 minversion = 2.5.0
 
 [testenv]
-basepython = python3.8
+basepython = python3.9
 deps =
     -rrequirements.txt
 setenv =


### PR DESCRIPTION
Use Python 3.9, now available in Ubuntu 20.04.
