### PR TITLE
Security headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ devserver: webpack
 	YARRHARR_CONF='yarrharr/tests/*.ini' tox -e run -- django-admin runserver 127.0.0.1:8888
 
 .PHONY: realserver
-realserver:
-	NODE_ENV=development RUNMODE=dev-static npm run webpack
+realserver: webpack
 	tox -e run -- django-admin migrate
 	tox -e run -- django-admin collectstatic --noinput
 	tox -e run -- yarrharr

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     -rrequirements.txt
 setenv =
     YARRHARR_CONF={env:YARRHARR_CONF:{toxinidir}/yarrharr/tests/dev.ini}
+    YARRHARR_TESTING=yes
     DJANGO_SETTINGS_MODULE=yarrharr.settings
     PYTHONDONTWRITEBYTECODE=yes
 ; This must remain disabled due to https://github.com/twisted/treq/issues/226

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright © 2013, 2015, 2016, 2017, 2018, 2020 Tom Most <twm@freecog.net>
+# Copyright © 2013, 2015, 2016, 2017, 2018, 2020, 2022 Tom Most <twm@freecog.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -312,16 +311,19 @@ class Root(FallbackResource):
         # sanitizer.
         request.setHeader(b"Referrer-Policy", b"same-origin")
         request.setHeader(b"X-Content-Type-Options", b"nosniff")
+        request.setHeader(b"Cross-Origin-Opener-Policy", b"same-origin")
 
         request.setHeader(
             b"Content-Security-Policy",
-            # b"default-src 'none'; "
-            b"img-src *; "
-            b"script-src 'self' 'unsafe-inline'; "
-            b"style-src 'self'; "
-            b"frame-ancestors 'none'; "
-            b"form-action 'self'; "
-            b"report-uri /csp-report",
+            (
+                # b"default-src 'none'; "
+                b"img-src *; "
+                b"script-src 'self' 'unsafe-inline'; "
+                b"style-src 'self'; "
+                b"frame-ancestors 'none'; "
+                b"form-action 'self'; "
+                b"report-uri /csp-report"
+            ),
         )
 
         return super().getChildWithDefault(name, request)

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -30,9 +30,9 @@ Yarrharr production server via Twisted Web
 import io
 import json
 import logging
+import os
 import re
 import sys
-import os
 from base64 import b64encode
 
 import attr

--- a/yarrharr/conf.py
+++ b/yarrharr/conf.py
@@ -215,9 +215,14 @@ def read_yarrharr_conf(files, namespace):
         "yarrharr",
     )
 
-    # Disable Django's logging configuration stuff (except when running under
-    # the dev server).
     if "runserver" not in sys.argv:
+        # Disable Django's logging configuration stuff (except when running under
+        # the dev server).
         namespace["LOGGING_CONFIG"] = None
+    else:
+        # Under the dev server send the same headers as the real Twisted server.
+        # See yarrharr.application.Root.
+        namespace["SECURE_REFERRER_POLICY"] = "same-origin"
+        namespace["SECURE_CROSS_ORIGIN_OPENER_POLICY"] = "same-origin"
 
     return conf

--- a/yarrharr/conf.py
+++ b/yarrharr/conf.py
@@ -172,6 +172,7 @@ def read_yarrharr_conf(files, namespace):
     # in the default list as Yarrharr's templates don't use them.
     context_processors = [
         "django.contrib.auth.context_processors.auth",
+        "yarrharr.context_processors.csp",
     ]
     if namespace["DEBUG"]:
         # When in debug mode, display SQL queries for requests coming from the
@@ -219,10 +220,12 @@ def read_yarrharr_conf(files, namespace):
         # Disable Django's logging configuration stuff (except when running under
         # the dev server).
         namespace["LOGGING_CONFIG"] = None
+        namespace["YARRHARR_SCRIPT_NONCE"] = True
     else:
         # Under the dev server send the same headers as the real Twisted server.
         # See yarrharr.application.Root.
         namespace["SECURE_REFERRER_POLICY"] = "same-origin"
         namespace["SECURE_CROSS_ORIGIN_OPENER_POLICY"] = "same-origin"
+        namespace["YARRHARR_SCRIPT_NONCE"] = False
 
     return conf

--- a/yarrharr/context_processors.py
+++ b/yarrharr/context_processors.py
@@ -27,15 +27,25 @@
 Yarrharr template context processors.
 """
 
+import os
+
 from django.conf import settings
 
 
 def csp(request):
     """
-    Add the script nonce from the ``Content-Security-Policy`` header to the request context.
+    Add the script nonce from the ``Content-Security-Policy`` header to the
+    request context.
     """
     if settings.YARRHARR_SCRIPT_NONCE:
-        nonce = request.headers["Yarrharr-Script-Nonce"]
+        try:
+            nonce = request.headers["Yarrharr-Script-Nonce"]
+        except KeyError:
+            if os.environ.get("YARRHARR_TESTING") == "yes":
+                # Only ignore this in unit tests so we fail safe in production.
+                nonce = None
+            else:
+                raise
     else:
         nonce = None
     return {"script_nonce": nonce}

--- a/yarrharr/context_processors.py
+++ b/yarrharr/context_processors.py
@@ -1,0 +1,41 @@
+# Copyright © 2022 Tom Most <twm@freecog.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this Program, or any covered work, by linking or
+# combining it with OpenSSL (or a modified version of that library),
+# containing parts covered by the terms of the OpenSSL License, the
+# licensors of this Program grant you additional permission to convey
+# the resulting work.  Corresponding Source for a non-source form of
+# such a combination shall include the source code for the parts of
+# OpenSSL used as well as that of the covered work.
+
+"""
+Yarrharr template context processors.
+"""
+
+from django.conf import settings
+
+
+def csp(request):
+    """
+    Add the script nonce from the ``Content-Security-Policy`` header to the request context.
+    """
+    if settings.YARRHARR_SCRIPT_NONCE:
+        nonce = request.headers["Yarrharr-Script-Nonce"]
+    else:
+        nonce = None
+    return {"script_nonce": nonce}

--- a/yarrharr/templates/base.html
+++ b/yarrharr/templates/base.html
@@ -12,8 +12,8 @@
         <link rel="apple-touch-icon-precomposed" type="image/png" href="{% static 'icon-*.png'|newest_static %}">
         <link rel="manifest" href="{% url 'manifest' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'main-*.css'|newest_static %}">
-        <script src="{% static 'runtime-*.js'|newest_static %}" defer></script>
-        <script src="{% static 'main-*.js'|newest_static %}" defer></script>
+        <script src="{% static 'runtime-*.js'|newest_static %}" defer nonce="{{ script_nonce }}"></script>
+        <script src="{% static 'main-*.js'|newest_static %}" defer nonce="{{ script_nonce }}"></script>
     </head>
     <body>
         {% include "icons.html" %}

--- a/yarrharr/templates/components.html
+++ b/yarrharr/templates/components.html
@@ -38,7 +38,7 @@
 </template>
 
 
-<script type="module">
+<script type="module" nonce="{{ script_nonce }}">
 {% url 'api-flags' as flag_api_url %}
 const flagsApi = "{{ flag_api_url|escapejs }}";
 

--- a/yarrharr/templates/header.html
+++ b/yarrharr/templates/header.html
@@ -29,7 +29,7 @@
 
 </div>
 
-<script type="module">
+<script type="module" nonce="{{ script_nonce }}">
   const b = document.getElementById("layout-button");
   const y = document.getElementById("yarrharr");
 
@@ -60,7 +60,7 @@
   readFromStorage();
 </script>
 
-<script type="module">
+<script type="module" nonce="{{ script_nonce }}">
   const b = document.getElementById("fullscreen-button");
   b.onclick = e =>  {
     if (document.fullscreenElement) {

--- a/yarrharr/tests/test_conf.py
+++ b/yarrharr/tests/test_conf.py
@@ -119,6 +119,7 @@ class ConfTests(unittest.TestCase):
                         "OPTIONS": {
                             "context_processors": [
                                 "django.contrib.auth.context_processors.auth",
+                                "yarrharr.context_processors.csp",
                             ],
                         },
                     }
@@ -146,6 +147,7 @@ class ConfTests(unittest.TestCase):
                     "yarrharr",
                 ),
                 "LOGGING_CONFIG": None,
+                "YARRHARR_SCRIPT_NONCE": True,
             },
         )
 
@@ -196,6 +198,7 @@ class ConfTests(unittest.TestCase):
                         "OPTIONS": {
                             "context_processors": [
                                 "django.contrib.auth.context_processors.auth",
+                                "yarrharr.context_processors.csp",
                                 "django.template.context_processors.debug",
                             ],
                         },
@@ -224,6 +227,7 @@ class ConfTests(unittest.TestCase):
                     "yarrharr",
                 ),
                 "LOGGING_CONFIG": None,
+                "YARRHARR_SCRIPT_NONCE": True,
             },
         )
 


### PR DESCRIPTION
- Set Cross-Origin-Opener-Policy: same-origin
- Set security headers in dev
- Inject `script_nonce` into templates
- Restore "make realserver"
- Inject `<script nonce>` everywhere

Closes #937.
