### PR TITLE
Replace pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,8 +64,6 @@ pycparser==2.21
     # via cffi
 pyopenssl==21.0.0
     # via twisted
-pytz==2021.3
-    # via yarrharr (setup.py)
 requests==2.26.0
     # via treq
 service-identity==21.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         "Django >=4.0.2,<4.1",
         "Twisted[tls,http2] >= 22.1.0",
         "treq >= 22.2.0",
-        "pytz",
         "feedparser >= 6.0.8",
         "html5lib == 1.1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "feedparser >= 6.0.8",
         "html5lib == 1.1",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     entry_points={
         "console_scripts": [
             "yarrharr=yarrharr.scripts.yarrharr:main",
@@ -34,7 +34,7 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Internet :: WWW/HTTP",
     ],
     packages=find_packages(),

--- a/yarrharr/fetch.py
+++ b/yarrharr/fetch.py
@@ -30,7 +30,8 @@ Feed fetcher based on Twisted Web
 
 import hashlib
 import html
-from datetime import datetime, timezone as tz
+from datetime import datetime
+from datetime import timezone as tz
 from io import BytesIO
 
 import attr

--- a/yarrharr/fetch.py
+++ b/yarrharr/fetch.py
@@ -30,12 +30,11 @@ Feed fetcher based on Twisted Web
 
 import hashlib
 import html
-from datetime import datetime
+from datetime import datetime, timezone as tz
 from io import BytesIO
 
 import attr
 import feedparser
-import pytz
 import treq
 from django.db import OperationalError, transaction
 from django.utils import timezone
@@ -683,7 +682,7 @@ def as_datetime(t):
         hour=t[3],
         minute=t[4],
         second=t[5],
-        tzinfo=pytz.utc,
+        tzinfo=tz.utc,
     )
 
 

--- a/yarrharr/tests/test_fetch.py
+++ b/yarrharr/tests/test_fetch.py
@@ -24,7 +24,8 @@
 # OpenSSL used as well as that of the covered work.
 
 import hashlib
-from datetime import datetime, timedelta, timezone as tz
+from datetime import datetime, timedelta
+from datetime import timezone as tz
 from importlib import resources
 from unittest import mock
 

--- a/yarrharr/tests/test_fetch.py
+++ b/yarrharr/tests/test_fetch.py
@@ -24,12 +24,11 @@
 # OpenSSL used as well as that of the covered work.
 
 import hashlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as tz
 from importlib import resources
 from unittest import mock
 
 import attr
-import pytz
 from attr.validators import instance_of
 from django.contrib.auth.models import User
 from django.test import TestCase as DjangoTestCase
@@ -651,8 +650,8 @@ class FetchTests(SynchronousTestCase):
         self.assertIsInstance(outcome, MaybeUpdated)
         self.assertEqual(
             [
-                datetime(2017, 3, 17, tzinfo=pytz.UTC),
-                datetime(2013, 1, 1, tzinfo=pytz.UTC),
+                datetime(2017, 3, 17, tzinfo=tz.utc),
+                datetime(2013, 1, 1, tzinfo=tz.utc),
             ],
             [article.date for article in outcome.articles],
         )


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/4.0/#zoneinfo-default-timezone-implementation