### PR TITLE
Fix static file serving

### DIFF
--- a/bin/compile-static.py
+++ b/bin/compile-static.py
@@ -46,6 +46,7 @@ Temporary files are generated in the build/ directory.
 import argparse
 import asyncio
 import hashlib
+import re
 import shlex
 from asyncio.subprocess import PIPE
 from dataclasses import dataclass
@@ -59,6 +60,7 @@ import zopfli.gzip
 repo_root = Path(__file__).parent.parent
 
 COMPRESS_EXTS = (".js", ".css", ".svg", ".ico", ".map")
+_validName = re.compile(r"\A[a-zA-Z0-9]+-[a-z0-9]+(\.[a-z0-9]+)+\Z")
 
 _parser = argparse.ArgumentParser()
 _parser.add_argument("--out-dir", type=Path, default=repo_root / "yarrharr" / "static")
@@ -71,7 +73,9 @@ def hashname(prefix: str, ext: str, content: bytes) -> str:
     """
     Generate a filename based on file content.
     """
-    return f"{prefix}-{hashlib.sha256(content).hexdigest()[:12]}.{ext}"
+    name = f"{prefix}-{hashlib.sha256(content).hexdigest()[:12]}.{ext}"
+    assert _validName.match(name) is not None, f"{name=} isn't valid"
+    return name
 
 
 @dataclass
@@ -92,6 +96,8 @@ class Writer:
         """
         Write a file to the static directory from an in-memory buffer.
         """
+        assert _validName.match(name) is not None, f"{name=} isn't valid"
+
         path = self._out_dir / name
         path.write_bytes(data)
 

--- a/yarrharr/application.py
+++ b/yarrharr/application.py
@@ -207,7 +207,6 @@ class Static(Resource):
     """
 
     _dir = FilePath(settings.STATIC_ROOT)
-    _validName = re.compile(rb"^[a-zA-Z0-9]+-[a-zA-Z0-9]+(\.[a-z]+)+$")
     # NOTE: RFC 7231 § 5.3.4 is not completely clear about whether
     # content-coding tokens are case-sensitive or not. The "identity" token
     # appears in EBNF and is therefore definitely case-insensitive, but the
@@ -227,6 +226,8 @@ class Static(Resource):
         b".woff2": "font/woff2",
         b".ttf": "font/ttf",
     }
+
+    _validName = re.compile(rb"\A[a-zA-Z0-9]+-[a-z0-9]+(\.[a-z0-9]+)+\Z")
 
     def _file(self, path, type, encoding=None):
         """
@@ -253,7 +254,7 @@ class Static(Resource):
 
          *  ``br``, which selects any Brotli-compressed ``.br`` variant of
             the file.
-         * ``gzip``, which selects any gzip-compressed ``.br`` variant of the
+         * ``gzip``, which selects any gzip-compressed ``.gz`` variant of the
             file. ``x-gzip`` is also supported.
 
         qvalues are ignored as browsers don't use them. This may produce an


### PR DESCRIPTION
Align the static compilation script and the the server code on what a valid filename is.  normalize.css was failing to load because its version segment is a dotted number rather than hex digits. The Newsreader font files failed to load because ".woff2" contains a digit.
