### PR TITLE
Prevent content styling collisions

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -96,7 +96,7 @@ a:visited[aria-disabled=true] {
     cursor: default;
 }
 
-main {
+#main {
     min-height: 100vh; /* push the footer off the page */
 }
 
@@ -333,7 +333,7 @@ form.small-form {
     }
 }
 
-footer {
+#footer {
     padding: 3em 0.25em;
     text-align: center;
     background: var(--footer-background-color);

--- a/less/main.less
+++ b/less/main.less
@@ -81,10 +81,6 @@ a .underline {
     text-decoration-line: underline;
     text-decoration-color: var(--underline-color);
 }
-// FIXME: Remove all [role=button], just use <button>
-a[role=button] {
-    text-decoration-line: none;
-}
 a:visited {
     text-decoration-style: dashed;
 }

--- a/yarrharr/templates/base.html
+++ b/yarrharr/templates/base.html
@@ -18,10 +18,10 @@
     <body>
         {% include "icons.html" %}
 
-        <main role=main>
+        <main id="main">
             {% block content %}{% endblock %}
         </main>
-        <footer>
+        <footer id="footer">
             {% if user.is_authenticated %}
                 <p><a href="{% url 'home' %}">Home</a> ∙ <a href="{% url 'logout' %}">Log out</a>
             {% endif %}


### PR DESCRIPTION
- Remove dead a[role=button] rule
- Use selectors that can't collide with content
