### PR TITLE
Increase the narrow monospace breakpoint

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -50,7 +50,7 @@
     }
 }
 
-@media screen and (max-width: 32rem) {
+@media screen and (max-width: 45rem) {
     :root {
         --font-wdth-mono: 80;
     }


### PR DESCRIPTION
This produces narrow monospace text on my tablet in portrait mode, but full-width monospace in landscape mode, which looks about right.

Fixes #1010.
