### PR TITLE
Run tox -e static in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - run: "python -m tox"
 
   webpack:
-    name: "make static"
+    name: "tox -e static"
 
     runs-on: ubuntu-20.04
 
@@ -76,4 +76,4 @@ jobs:
 
     - run: "python -m tox -e static --notest"
 
-    - run: "make static"
+    - run: "tox -e static"


### PR DESCRIPTION
Rather than "make static", invoke "tox -e static" directly.
