### PR TITLE
Bump the test dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ sqlparse==0.4.4
     # via django
 tomli==2.0.1
     # via incremental
-treq==23.11.0
+treq==24.9.1
     # via yarrharr (pyproject.toml)
 twisted[tls]==24.7.0
     # via
@@ -80,6 +80,7 @@ twisted[tls]==24.7.0
 typing-extensions==4.7.1
     # via
     #   asgiref
+    #   treq
     #   twisted
 urllib3==2.2.2
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.2.0
     # via requests
 constantly==15.1.0
     # via twisted
-cryptography==43.0.0
+cryptography==43.0.3
     # via
     #   pyopenssl
     #   service-identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ attrs==24.2.0
     #   yarrharr (pyproject.toml)
 automat==22.10.0
     # via twisted
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 cffi==1.15.1
     # via cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ cryptography==43.0.0
     # via
     #   pyopenssl
     #   service-identity
-django==4.2.15
+django==4.2.16
     # via yarrharr (pyproject.toml)
 feedparser==6.0.10
     # via yarrharr (pyproject.toml)

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -8,7 +8,7 @@ bleach==6.0.0
     # via readme-renderer
 build==1.2.1
     # via -r requirements_release.in
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 cffi==1.15.1
     # via cryptography

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -14,7 +14,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
-cryptography==43.0.1
+cryptography==43.0.3
     # via secretstorage
 docutils==0.20.1
     # via readme-renderer


### PR DESCRIPTION
- **django 4.2.16**
- **cryptography 43.0.3**
- **certifi 2024.8.30**
- **treq 24.9.1**

Addresses a few security alerts.
